### PR TITLE
Update gateway.txt

### DIFF
--- a/www/gateway.txt
+++ b/www/gateway.txt
@@ -4,3 +4,6 @@ https://ipfs.infura.io/ipfs/@
 https://siderus.io/ipfs/@
 https://ipfs.jes.xxx/ipfs/@
 https://www.eternum.io/ipfs/@
+https://xmine128.tk/ipfs/@
+https://hardbin.com/ipfs/@
+https://ipfs.wa.hle.rs/ipfs/@


### PR DESCRIPTION
Some additional gateways; there used to be more, but they have been offline for some time now.

Question: doesn't the main gateway `ipfs.io` need to be `https://ipfs.io/ipfs/@